### PR TITLE
MariaDB Socket Configuration for el9

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,6 +15,8 @@ jobs:
         os:
           - dist: centos
             release: 8-Stream
+          - dist: centos
+            release: 9-Stream
           - dist: debian
             release: buster
           - dist: debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
     - name: EL
       version:
         - "8"
+        - "9"
     - name: Debian
       versions:
         - buster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
     login_user: "{{ database_root_user }}"
     login_password: "{{ database_root_password }}"
     check_implicit_admin: true
+    login_unix_socket: /var/lib/mysql/mysql.sock
 
 - name: Set MariaDB root user password (Debian)
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This role fails on el9 systems.
Setting a socket location fixes the problem.

This needs to be tested on el8