### PR TITLE
Fix os version specification

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   min_ansible_version: "2.09"
   platforms:
     - name: EL
-      version:
+      versions:
         - "8"
         - "9"
     - name: Debian


### PR DESCRIPTION
This patch fixes the specification for supported `EL` versions which had a typo in the dictionary key.