### PR TITLE
replace password with unix socket authentication for root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ ansible-galaxy collection install community.mysql
 
 ## Role Variables
 
-You have to specify passwords for the opencast user that accesses the database (`database_password`)
-and the database root user (`database_root_password`).
-Note that once you set the password for the root user, you can _not_ change it again with this role.
+You have to specify a password for the opencast user that accesses the database (`database_password`).
 
 Further config options are optional.
+For example, you can optionally specify a password of the database root user (`database_root_password`) in case you 
+provision to an already installed MariaDB instance where a database root user password has already been set and 
+unix_socket authentication has been deactivated.
 Have a look at the [defaults](defaults/main.yml) to see all variables.
 
 ## Example Playbook
@@ -32,7 +33,6 @@ Just add the role to your playbook:
   roles:
     - role: elan.opencast_mariadb
       database_password: '1234'
-      database_root_password: '4567'
 ```
 
 ## Development

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ database_name: opencast
 database_user_name: opencast
 # mariadb root user
 database_root_user: root
+# mariadb root user password,
+# only used for authentication to a db with an already set root password and disabled unix_socket authentication
+database_root_password: '4567'
 
 # mariadb config options
 opencast_mariadb_max_connections: 512

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,12 @@
 ---
-- name: Install MariaDB on RedHat Systems
-  when: ansible_os_family == 'RedHat'
-  ansible.builtin.dnf:
-    name:
-      - mariadb-server
-      - mariadb
-      - python3-PyMySQL
+- name: Loading platform variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+  tags: always
 
-- name: Install MariaDB on Debian Systems
-  when: ansible_os_family == 'Debian'
-  ansible.builtin.apt:
-    name:
-      - mariadb-server
-      - mariadb-client
-      - python3-pymysql
+- name: Install MariaDB
+  ansible.builtin.package:
+    name: "{{ mariadb_packages }}"
+    state: present
 
 - name: Create systemd configuration directory
   ansible.builtin.file:
@@ -39,7 +32,7 @@
 - name: Configure mariadb
   notify: Restart MariaDB
   community.general.ini_file:
-    dest: "{{ '/etc/mysql/mariadb.conf.d/50-server.cnf' if ansible_os_family == 'Debian' else '/etc/my.cnf.d/opencast.cnf' }}"
+    dest: "{{ mariadb_configuration_file }}"
     section: mysqld
     option: "{{ item.key }}"
     value: "{{ item.value }}"
@@ -69,26 +62,6 @@
     delay: 1
     timeout: 30
 
-- name: Set MariaDB root user password (RedHat)
-  when: ansible_os_family == 'RedHat'
-  community.mysql.mysql_user:
-    name: "{{ database_root_user }}"
-    password: "{{ database_root_password }}"
-    login_user: "{{ database_root_user }}"
-    login_password: "{{ database_root_password }}"
-    check_implicit_admin: true
-    login_unix_socket: /var/lib/mysql/mysql.sock
-
-- name: Set MariaDB root user password (Debian)
-  when: ansible_os_family == 'Debian'
-  community.mysql.mysql_user:
-    name: "{{ database_root_user }}"
-    password: "{{ database_root_password }}"
-    login_user: "{{ database_root_user }}"
-    login_password: "{{ database_root_password }}"
-    check_implicit_admin: true
-    login_unix_socket: /run/mysqld/mysqld.sock
-
 - name: Create Opencast database user
   community.mysql.mysql_user:
     name: "{{ database_user_name }}"
@@ -97,6 +70,8 @@
     priv: "{{ database_name }}.*:ALL,GRANT"
     login_user: "{{ database_root_user }}"
     login_password: "{{ database_root_password }}"
+    check_implicit_admin: true
+    login_unix_socket: "{{ mariadb_socket_path }}"
 
 - name: Create Opencast database
   community.mysql.mysql_db:
@@ -105,30 +80,32 @@
     state: present
     login_user: "{{ database_root_user }}"
     login_password: "{{ database_root_password }}"
+    check_implicit_admin: true
+    login_unix_socket: "{{ mariadb_socket_path }}"
 
-## configuration steps to mimic what 'mysql_secure_installation' does:
+## some configuration steps to mimic what 'mysql_secure_installation' does:
 
 - name: Delete anonymous user
   community.mysql.mysql_user:
     user: ""
-    host: "{{ item }}"
+    host_all: true
     state: absent
     login_user: "{{ database_root_user }}"
     login_password: "{{ database_root_password }}"
-  loop:
-    - "localhost"
-    - "{{ ansible_fqdn }}"
-  no_log: true
+    check_implicit_admin: true
+    login_unix_socket: "{{ mariadb_socket_path }}"
 
 - name: Ensure root user can only connect from the local machine
-  community.mysql.mysql_user:
-    user: "{{ database_root_user }}"
-    password: "{{ database_root_password }}"
-    host: "{{ item }}"
+  community.mysql.mysql_query:
+    query:
+      - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
     login_user: "{{ database_root_user }}"
     login_password: "{{ database_root_password }}"
-  loop:
-    - "::1"
-    - "localhost"
-    - "{{ ansible_fqdn }}"
-  no_log: true
+    login_unix_socket: "{{ mariadb_socket_path }}"
+
+- name: Ensure unix socket as login method for root user
+  community.mysql.mysql_user:
+    name: "{{ database_root_user }}"
+    plugin: unix_socket
+    check_implicit_admin: true
+    login_unix_socket: "{{ mariadb_socket_path }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,10 @@
+---
+
+mariadb_packages:
+  - mariadb-server
+  - mariadb-client
+  - python3-pymysql
+
+mariadb_configuration_file: /etc/mysql/mariadb.conf.d/99-opencast.cnf
+
+mariadb_socket_path: /run/mysqld/mysqld.sock

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,10 @@
+---
+
+mariadb_packages:
+  - mariadb-server
+  - mariadb-client
+  - python3-pymysql
+
+mariadb_configuration_file: /etc/mysql/mariadb.conf.d/99-opencast.cnf
+
+mariadb_socket_path: /run/mysqld/mysqld.sock

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,9 +2,9 @@
 
 mariadb_packages:
   - mariadb-server
-  - mariadb-client
-  - python3-pymysql
+  - mariadb
+  - python3-PyMySQL
 
-mariadb_configuration_file: /etc/mysql/mariadb.conf.d/99-opencast.cnf
+mariadb_configuration_file: /etc/my.cnf.d/opencast.cnf
 
-mariadb_socket_path: /run/mysqld/mysqld.sock
+mariadb_socket_path: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
replace password with unix socket authentication for root user. Make database_root_password optional and use unix_socket as default auth plugin. Ensure that the tasks run for both Debian and RedHat based distros